### PR TITLE
fix: removing MemMap import (json.editor)

### DIFF
--- a/tools/generator/Dcm.py
+++ b/tools/generator/Dcm.py
@@ -4,7 +4,6 @@
 import os
 import json
 from .helper import *
-from .MemMap import *
 
 __all__ = ["Gen"]
 


### PR DESCRIPTION
Json.editor tool is breaking due to a faulty import (MemMap)
Seems that the file is not present in the module nor is it being used in the tool at all